### PR TITLE
Python script to query Ollama and generate training and validation partitions

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,11 +4,18 @@ import sys
 from pathlib import Path
 
 def query_ollama(prompt, model='mistral', context=''):
+    answer_marker = "Answer:"
+    followup_marker = "Follow-up question:"
+    full_prompt = f"{context}{prompt}\n{answer_marker}"
     url = 'http://localhost:11434/api/generate'
-    data = {"model": model, "stream": False, "prompt": context + prompt}
+    data = {"model": model, "stream": False, "prompt": full_prompt}
     response = requests.post(url, json=data)
     response.raise_for_status()
-    return response.json()['response'].strip()
+    full_response = response.json()['response'].strip()
+    parts = full_response.split(followup_marker)
+    answer = parts[0].replace(answer_marker, '').strip()
+    followup_question = parts[1].strip() if len(parts) > 1 else "No follow-up question provided."
+    return answer, followup_question
 
 def create_validation_file(train_file, valid_file, split_ratio):
     with open(train_file, 'r') as file:
@@ -29,10 +36,12 @@ def main(instructions_file, train_file, valid_file, split_ratio):
 
     for i, instruction in enumerate(instructions, start=1):
         print(f"Processing ({i}/{len(instructions)}): {instruction}")
-        answer = query_ollama(instruction)
-        result = f'<s>[INST] {instruction}[/INST] {answer}</s>\n'
+        answer, followup_question = query_ollama(instruction)
+        result = json.dumps({
+            'text': f'<s>[INST] {instruction}[/INST] {answer}</s>[INST]{followup_question}[/INST]'
+        }) + "\n"
         with open(train_file, 'a') as file:
-            file.write(json.dumps({'text': result}) + "\n")
+            file.write(result)
     
     create_validation_file(train_file, valid_file, split_ratio)
     print("Done! Training and validation JSONL files created.")

--- a/generate.py
+++ b/generate.py
@@ -1,0 +1,43 @@
+import json
+import requests
+import sys
+from pathlib import Path
+
+def query_ollama(prompt, model='mistral', context=''):
+    url = 'http://localhost:11434/api/generate'
+    data = {"model": model, "stream": False, "prompt": context + prompt}
+    response = requests.post(url, json=data)
+    response.raise_for_status()
+    return response.json()['response'].strip()
+
+def create_validation_file(train_file, valid_file, split_ratio):
+    with open(train_file, 'r') as file:
+        lines = file.readlines()
+    valid_lines = lines[:int(len(lines) * split_ratio)]
+    train_lines = lines[int(len(lines) * split_ratio):]
+    with open(train_file, 'w') as file:
+        file.writelines(train_lines)
+    with open(valid_file, 'w') as file:
+        file.writelines(valid_lines)
+
+def main(instructions_file, train_file, valid_file, split_ratio):
+    if not Path(instructions_file).is_file():
+        sys.exit(f'{instructions_file} not found.')
+
+    with open(instructions_file, 'r') as file:
+        instructions = json.load(file)
+
+    for i, instruction in enumerate(instructions, start=1):
+        print(f"Processing ({i}/{len(instructions)}): {instruction}")
+        answer = query_ollama(instruction)
+        result = f'<s>[INST] {instruction}[/INST] {answer}</s>\n'
+        with open(train_file, 'a') as file:
+            file.write(json.dumps({'text': result}) + "\n")
+    
+    create_validation_file(train_file, valid_file, split_ratio)
+    print("Done! Training and validation JSONL files created.")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        sys.exit("Usage: python script.py <instructions.json> <train.jsonl> <valid.jsonl> <split_ratio>")
+    main(sys.argv[1], sys.argv[2], sys.argv[3], float(sys.argv[4]))


### PR DESCRIPTION
Python script to generate training and validation files after querying Mistral via Ollama

I came across this part of [your blog post](https://apeatling.com/articles/part-2-building-your-training-data-for-fine-tuning/):

>I’d like to get this script into Python and have it accept arguments, but this quick PHP script will do for now. The script doesn’t handle follow up responses, you’d need to modify and extend it to manage that.

I hope this does what you had in mind, but please let me know if there's anything else.

Instructions to test:

- Clone branch
- Run `python generate.py instructions-example.json train.jsonl valid.jsonl 0.2`